### PR TITLE
Fix TypeScript project references

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./client/tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./server/tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  }
+}


### PR DESCRIPTION
## Summary
- add root project configs for client and server

## Testing
- `npx tsc -b --pretty false` *(fails: JSX runtime module not found)*
